### PR TITLE
Put Ginkgo opts before the package list

### DIFF
--- a/jobs/smoke_tests/templates/test.erb
+++ b/jobs/smoke_tests/templates/test.erb
@@ -22,4 +22,4 @@ TEST_BINARIES=$(ls smoke/**/*.test)
 
 echo "Running binaries ${TEST_BINARIES}"
 
-ginkgo --succinct -slowSpecThreshold=300 -p ${TEST_BINARIES} <%= properties.smoke_tests.ginkgo_opts %>
+ginkgo --succinct -slowSpecThreshold=300 -p <%= properties.smoke_tests.ginkgo_opts %> ${TEST_BINARIES}


### PR DESCRIPTION
My ginkgo_opts don't work unless they are specified before the package list.