### PR TITLE
Bump go, golang dependencies and blobs in release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # cf-smoke-tests-release
 
-## Updating Blobs
+This is the bosh release for [cf-smoke-tests](https://github.com/cloudfoundry/cf-smoke-tests). Once deployed, the tests can be run as a bosh errand:
+
+```console
+bosh -d <DEPLOYMENT> run-errand smoke_tests
+```
+
+## Contributing
+
+### Updating Blobs
 Download the binary you would like to include as a blob
 
 Grab `private.yml` from Lastpass (cf-smoke-test-release-bucket aws key) and copy the contents into `config/private.yml` in your local repo. Note that blob management does not require a bosh director.
@@ -13,7 +21,7 @@ Run `bosh remove-blob` with the old blob you want to remove
 
 For the windows cf cli, ensure that references/regex patterns in the `/packages/cf_cli_windows/packages` and `/packages/cf_cli_windows/spec` files correctly match the newly uploaded binary file name
 
-## Creating and validating a release locally
+### Creating and validating a release locally
 
 Run `git submodule update --init --recursive`
 
@@ -25,20 +33,3 @@ Get a bosh director with cf-deployment and update your bosh manifest to point sm
 Run `bosh deploy` to have bosh pull that latest dev release
 
 Run `bosh run-errand smoke-tests`
-
-## Update Go Version
-
-To update go version cf-smoke-test-release. Grab the S3 key for the cf-smoke-test-release blobs bucket.
-
-Clone the golang-release: https://github.com/bosh-packages/golang-release
-Make sure the repo is on a branch with the new go version.
-
-Next follow the steps, but it should be just running:
-
-`bosh vendor-package golang-1.x-windows <path to the golang-release>`
-
-and
-
-`bosh vendor-package golang-1.x-linux <path to the golang-release>`
-
-Then commit.

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,23 +1,27 @@
 # cf-smoke-tests-release CI
 
 ## Purpose
-This pipeline keeps the components of `cf-smoke-tests-release` up to date and verifies all changes with automated testing.
-It also provides manually triggered jobs for publishing new final bosh releases.
+This pipeline keeps the components of `cf-smoke-tests` and `cf-smoke-tests-release` up to date, and verifies all changes with automated testing.
+
+## Where
+The pipeline is public and runs at [app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-smoke-tests](https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-smoke-tests)
 
 ### Automated Testing
 All changes to `cf-smoke-tests-release` are automatically verified by the following steps:
-- Claiming a working bosh-deployed CF environment (`stable-acquire-pool` job)
-- Deploying the smoke tests with the same bosh director (`deploy-updated-smokes` job)
-- Running the `smoke_tests` errand on that bosh deployment (`run-smokes-errand` job)
-- Deleting the deployment of `cf-smoke-tests-release` and releasing the environment (`delete-smokes-deployment` job)
+- Claiming a working bosh-deployed CF environment (`claim-cats-pool`)
+- Deploying the smoke tests with the same bosh director (`deploy-updated-smokes`)
+- Running the `smoke_tests` errand on that bosh deployment (`run-smokes-errand`)
+- Deleting the `cf-smoke-tests-release` deployment (`delete-smokes-deployment`) and cutting a release (`create-final-release`)
 
 ### Component bumping
-Two jobs ensure that `cf-smoke-tests-release` uses the latest version of both `cf-smoke-tests` and the `cf-test-helpers`
-repos by updating the submodules for each.
-
-- `bump-cf-smoke-tests`
-- `bump-cf-test-helpers`
+The following two pipeline jobs automatically bump dependencies in the `cf-smoke-tests` and `cf-smoke-tests-release` repositories respectively:
+1. `update-cf-smoke-tests` bumps:
+    * the [cf-test-helpers](https://github.com/cloudfoundry/cf-test-helpers) submodule
+    * go (1.x minor versions only) and go modules in `go.mod`
+2. `update-cf-smoke-tests-release` bumps:
+    * the cf-smoke-tests submodule
+    * the golang package (version is pinned to that found in `go.mod` in cf-smoke-tests)
+    * references to the golang package in all files in `jobs/`, `/packages/smoke_tests` and `/packages/smoke_tests_windows`
 
 ### Cutting new final releases
-The `create-final-release` job must be triggered manually, and will automatically create a bosh final release for the
-latest commit to have passed the verification steps.
+The `create-final-release` job is triggered automatically when new commits to this repo pass the jobs `deploy-updated-smokes`, `run-smokes-errand` and `delete-smokes-deployment`, but not if those commits only change files matching the following paths: `releases/**`, `.final_builds/**`, `ci/**`, and `.envrc`

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,7 +1,7 @@
 # cf-smoke-tests-release CI
 
 ## Purpose
-This pipeline keeps the components of `cf-smoke-tests` and `cf-smoke-tests-release` up to date, and verifies all changes with automated testing.
+This pipeline keeps the components of `cf-smoke-tests` and `cf-smoke-tests-release` (this repo) up to date, and verifies all changes with automated testing.
 
 ## Where
 The pipeline is public and runs at [app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-smoke-tests](https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-smoke-tests)
@@ -13,15 +13,14 @@ All changes to `cf-smoke-tests-release` are automatically verified by the follow
 - Running the `smoke_tests` errand on that bosh deployment (`run-smokes-errand`)
 - Deleting the `cf-smoke-tests-release` deployment (`delete-smokes-deployment`) and cutting a release (`create-final-release`)
 
-### Component bumping
-The following two pipeline jobs automatically bump dependencies in the `cf-smoke-tests` and `cf-smoke-tests-release` repositories respectively:
-1. `update-cf-smoke-tests` bumps:
-    * the [cf-test-helpers](https://github.com/cloudfoundry/cf-test-helpers) submodule
-    * go (1.x minor versions only) and go modules in `go.mod`
-2. `update-cf-smoke-tests-release` bumps:
-    * the cf-smoke-tests submodule
-    * the golang package (version is pinned to that found in `go.mod` in cf-smoke-tests)
+### Version bumping
+The following two pipeline jobs automatically bump the versions of dependencies in the `cf-smoke-tests` and `cf-smoke-tests-release` repos:
+1. `update-cf-smoke-tests` bumps the following in cf-smoke-tests:
+    * go (1.x minor versions only) and its dependencies in [go.mod](https://github.com/cloudfoundry/cf-smoke-tests/blob/main/go.mod), including [cf-test-helpers](https://github.com/cloudfoundry/cf-test-helpers)
+2. `update-cf-smoke-tests-release` bumps cf-smoke-tests-release:
+    * its cf-smoke-tests submodule
+    * its golang package (this follows the `go` version in cf-smoke-tests' [go.mod](https://github.com/cloudfoundry/cf-smoke-tests/blob/main/go.mod))
     * references to the golang package in all files in `jobs/`, `/packages/smoke_tests` and `/packages/smoke_tests_windows`
 
-### Cutting new final releases
-The `create-final-release` job is triggered automatically when new commits to this repo pass the jobs `deploy-updated-smokes`, `run-smokes-errand` and `delete-smokes-deployment`, but not if those commits only change files matching the following paths: `releases/**`, `.final_builds/**`, `ci/**`, and `.envrc`
+### Cutting a final release
+The `create-final-release` job is triggered automatically when new commits to this repo pass the jobs `deploy-updated-smokes`, `run-smokes-errand` and `delete-smokes-deployment` _unless_ those commits only change files matching the following paths: `releases/**`, `.final_builds/**`, `ci/**`, and `.envrc`

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,6 +1,26 @@
 ---
+groups:
+- name: update-dependencies
+  jobs:
+  - update-cf-smoke-tests
+  - update-cf-smoke-tests-release
+- name: test-and-release
+  jobs:
+  - claim-cats-pool
+  - deploy-updated-smokes
+  - run-smokes-errand
+  - delete-smokes-deployment
+  - create-final-release
+
+release_lock: &release_lock_if_not_success
+  on_failure: &release_lock
+    put: cats-pool
+    params:
+      release: cats-pool
+  on_error: *release_lock
+  on_abort: *release_lock
+
 resources:
-# Weekly Trigger
 - name: weekly-trigger
   type: time
   icon: clock-outline
@@ -10,7 +30,6 @@ resources:
     location: America/Los_Angeles
     interval: 168h
 
-# Concourse Tasks
 - name: cf-deployment-concourse-tasks
   type: git
   icon: github
@@ -24,7 +43,6 @@ resources:
     uri: https://github.com/cloudfoundry/runtime-ci.git
     branch: main
 
-# Releases
 - name: cf-smoke-tests-release
   type: git
   icon: github
@@ -60,7 +78,6 @@ resources:
     uri: https://github.com/cloudfoundry/cf-test-helpers
     branch: main
 
-# ENV
 - name: relint-envs
   type: git
   icon: github
@@ -77,7 +94,6 @@ resources:
     pool: cats
     private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
 
-# Semantic Version
 - name: cf-smoke-tests-version
   type: semver
   source:
@@ -91,52 +107,96 @@ resources:
 - name: windows2019-stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-google-kvm-windows2019-go_agent
+    name: bosh-aws-xen-hvm-windows2019-go_agent
+
+- name: golang-release
+  type: git
+  source:
+    uri: https://github.com/bosh-packages/golang-release.git
 
 jobs:
-- name: bump-cf-test-helpers
+- name: update-cf-smoke-tests
+  serial: true
   public: true
+  serial_groups: [update-repositories]
   plan:
   - in_parallel:
-    - get: cf-smoke-tests
-    - get: runtime-ci
+    - get: golang-release
+      trigger: true
     - get: cf-test-helpers
       trigger: true
-
+    - get: runtime-ci
+    - get: cf-smoke-tests
+  - task: bump-go-deps
+    file: golang-release/ci/tasks/shared/bump-deps.yml
+    input_mapping:
+      input_repo: cf-smoke-tests
+    output_mapping:
+      output_repo: cf-smoke-tests
+    params:
+      SOURCE_PATH: .
   - task: run-cf-test-helpers-unit-tests
     file: runtime-ci/tasks/run-cf-test-helpers-unit-tests/task.yml
-
   - task: bump-cf-test-helpers
     file: runtime-ci/tasks/bump-cf-test-helpers/task.yml
     input_mapping:
       repository: cf-smoke-tests
+    output_mapping:
+      updated-repository: cf-smoke-tests
     params:
       USE_GO_MOD: true
       REPOSITORY: cloudfoundry/cf-smoke-tests
-
   - put: cf-smoke-tests
     params:
-      repository: updated-repository
+      repository: cf-smoke-tests
       rebase: true
 
-- name: bump-cf-smoke-tests
+- name: update-cf-smoke-tests-release
+  serial: true
   public: true
+  serial_groups: [update-repositories]
   plan:
   - in_parallel:
-    - get: cf-smoke-tests-release
-    - get: runtime-ci
     - get: cf-smoke-tests
       trigger: true
-
-  - task: bump-cf-smoke-tests
+    - get: golang-release
+      trigger: true
+      passed: [update-cf-smoke-tests]
+    - get: runtime-ci
+    - get: cf-smoke-tests-release
+  - task: bump-cf-smoke-tests-submodule
     file: runtime-ci/tasks/bump-cf-smoke-tests/task.yml
-
+    output_mapping:
+      updated-cf-smoke-tests-release: cf-smoke-tests-release
+  - task: get-submodule-go-version
+    file: cf-smoke-tests-release/ci/tasks/get-submodule-go-version/task.yml
+  - load_var: go_version
+    file: version/version
+  - task: bump-release-go-package
+    file: golang-release/ci/tasks/shared/bump-golang-package.yml
+    input_mapping:
+      input_repo: cf-smoke-tests-release
+    output_mapping:
+      output_repo: cf-smoke-tests-release
+    params:
+      PACKAGES: [golang-((.:go_version))-linux, golang-((.:go_version))-windows]
+      PRIVATE_YML: |
+        ---
+        blobstore:
+          provider: s3
+          options:
+            access_key_id: ((aws_access_key_id))
+            secret_access_key: ((aws_secret_access_key))
+  - task: bump-release-go-references
+    file: cf-smoke-tests-release/ci/tasks/bump-release-go-references/task.yml
+    params:
+      GO_VERSION: ((.:go_version))
   - put: cf-smoke-tests-release
     params:
-      repository: updated-cf-smoke-tests-release
+      repository: cf-smoke-tests-release
       rebase: true
 
-- name: cats-acquire-pool
+- name: claim-cats-pool
   public: true
   serial: true
   plan:
@@ -146,32 +206,28 @@ jobs:
     - get: cf-smoke-tests-release-trigger
       trigger: true
     - get: cf-smoke-tests-release
-
   - put: cats-pool
     params:
-      acquire: true
+      claim: cats
 
 - name: deploy-updated-smokes
-  serial_groups:
-  - smoke_tests
+  serial: true
   public: true
+  serial_groups: [smoke_tests]
+  <<: *release_lock_if_not_success
   plan:
   - in_parallel:
     - get: cats-pool
       trigger: true
-      passed:
-      - cats-acquire-pool
+      passed: [claim-cats-pool]
     - get: runtime-ci
     - get: cf-deployment-concourse-tasks
     - get: cf-smoke-tests-release-trigger
-      passed:
-      - cats-acquire-pool
+      passed: [claim-cats-pool]
     - get: cf-smoke-tests-release
-      passed:
-      - cats-acquire-pool
+      passed: [claim-cats-pool]
     - get: relint-envs
     - get: windows2019-stemcell
-
   - task: upload-windows2019-stemcell
     file: runtime-ci/tasks/bosh-upload-stemcell/task.yml
     input_mapping:
@@ -179,7 +235,6 @@ jobs:
       stemcell: windows2019-stemcell
     params:
       BBL_STATE_DIR: environments/test/cats/bbl-state
-
   - task: deploy-smoke-tests-errand
     file: runtime-ci/tasks/bosh-deploy-smokes/task.yml
     input_mapping:
@@ -190,24 +245,22 @@ jobs:
       CREDHUB_ENV_NAME: bosh-cats
 
 - name: run-smokes-errand
+  serial: true
+  public: true
   serial_groups:
   - smoke_tests
-  public: true
+  <<: *release_lock_if_not_success
   plan:
   - in_parallel:
     - get: cats-pool
       trigger: true
-      passed:
-      - deploy-updated-smokes
+      passed: [deploy-updated-smokes]
     - get: cf-deployment-concourse-tasks
     - get: cf-smoke-tests-release-trigger
-      passed:
-      - deploy-updated-smokes
+      passed: [deploy-updated-smokes]
     - get: cf-smoke-tests-release
-      passed:
-      - deploy-updated-smokes
+      passed: [deploy-updated-smokes]
     - get: relint-envs
-
   - task: run-smokes
     file: cf-deployment-concourse-tasks/run-errand/task.yml
     input_mapping:
@@ -216,7 +269,6 @@ jobs:
       BBL_STATE_DIR: environments/test/cats/bbl-state
       DEPLOYMENT_NAME: cf-smoke-tests
       ERRAND_NAME: smoke_tests
-
   - task: run-smokes-windows
     file: cf-deployment-concourse-tasks/run-errand/task.yml
     input_mapping:
@@ -227,24 +279,21 @@ jobs:
       ERRAND_NAME: smoke_tests_windows
 
 - name: delete-smokes-deployment
-  serial_groups:
-  - smoke_tests
+  serial: true
   public: true
+  serial_groups: [smoke_tests]
+  <<: *release_lock_if_not_success
   plan:
   - in_parallel:
     - get: cats-pool
       trigger: true
-      passed:
-      - run-smokes-errand
+      passed: [run-smokes-errand]
     - get: cf-deployment-concourse-tasks
     - get: cf-smoke-tests-release-trigger
-      passed:
-      - run-smokes-errand
+      passed: [run-smokes-errand]
     - get: cf-smoke-tests-release
-      passed:
-      - run-smokes-errand
+      passed: [run-smokes-errand]
     - get: relint-envs
-
   - task: delete-smoke-tests-deployment
     file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
     input_mapping:
@@ -253,25 +302,22 @@ jobs:
       BBL_STATE_DIR: environments/test/cats/bbl-state
       DEPLOYMENT_NAME: cf-smoke-tests
 
-  - put: cats-pool
-    params:
-      release: cats-pool
-
 - name: create-final-release
   serial: true
   public: true
+  <<: *release_lock_if_not_success
   plan:
   - in_parallel:
+    - get: cats-pool
+      trigger: true
+      passed: [delete-smokes-deployment]
     - get: cf-smoke-tests-release-trigger
-      passed:
-      - run-smokes-errand
+      passed: [delete-smokes-deployment]
       trigger: true
     - get: cf-smoke-tests-release
-      passed:
-      - run-smokes-errand
+      passed: [delete-smokes-deployment]
     - get: cf-smoke-tests-version
     - get: runtime-ci
-
   - task: create-final-release
     file: runtime-ci/tasks/create-final-release/task.yml
     input_mapping:
@@ -280,13 +326,12 @@ jobs:
     params:
       BLOBS_BUCKET_ACCESS_KEY_ID: ((cf_release_blobs_buckets_access_key_id))
       BLOBS_BUCKET_SECRET_KEY: ((cf_release_blobs_buckets_secrect_access_key))
-
   - put: cf-smoke-tests-release
     params:
       repository: final-release-repo
       rebase: true
       tag: cf-smoke-tests-version/version
-
   - put: cf-smoke-tests-version
     params:
       bump: patch
+  - *release_lock

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -107,7 +107,7 @@ resources:
 - name: windows2019-stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-aws-xen-hvm-windows2019-go_agent
+    name: bosh-google-kvm-windows2019-go_agent
 
 - name: golang-release
   type: git
@@ -118,7 +118,7 @@ jobs:
 - name: update-cf-smoke-tests
   serial: true
   public: true
-  serial_groups: [update-repositories]
+  serial_groups: [update-dependencies]
   plan:
   - in_parallel:
     - get: golang-release
@@ -154,7 +154,7 @@ jobs:
 - name: update-cf-smoke-tests-release
   serial: true
   public: true
-  serial_groups: [update-repositories]
+  serial_groups: [update-dependencies]
   plan:
   - in_parallel:
     - get: cf-smoke-tests

--- a/ci/tasks/bump-release-go-references/task.sh
+++ b/ci/tasks/bump-release-go-references/task.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+set -eu
+
+cf_smoke_tests_release_dir="$(pwd)/cf-smoke-tests-release"
+dirs="
+${cf_smoke_tests_release_dir}/jobs
+${cf_smoke_tests_release_dir}/packages/smoke_tests
+${cf_smoke_tests_release_dir}/packages/smoke_tests_windows
+"
+for dir in $dirs; do
+  find "$dir" -type f -exec sed -i -E "s/golang-1.[0-9]+-(windows|linux)/golang-${GO_VERSION}-\1/g" {} \;
+done
+
+if [[ $(git -C "$cf_smoke_tests_release_dir" status --porcelain) ]]; then
+  git -C "$cf_smoke_tests_release_dir" status
+  git config --global user.email "$GIT_USER_EMAIL"
+  git config --global user.name "$GIT_USER_NAME"
+  git -C "$cf_smoke_tests_release_dir" add "$cf_smoke_tests_release_dir"
+  git -C "$cf_smoke_tests_release_dir" commit -m "Consume go ${GO_VERSION} in jobs and smoke test packages"
+else
+  echo "no change, skipping commit..."
+fi

--- a/ci/tasks/bump-release-go-references/task.yml
+++ b/ci/tasks/bump-release-go-references/task.yml
@@ -1,0 +1,21 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cloudfoundry/relint-base
+
+inputs:
+- name: cf-smoke-tests-release
+
+outputs:
+- name: cf-smoke-tests-release
+      
+params:
+  GO_VERSION:
+  GIT_USER_NAME: CI Bot
+  GIT_USER_EMAIL: bots@cloudfoundry.org
+
+run:
+  path: cf-smoke-tests-release/ci/tasks/bump-release-go-references/task.sh

--- a/ci/tasks/get-submodule-go-version/task.sh
+++ b/ci/tasks/get-submodule-go-version/task.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+set -e
+
+version_output="$(pwd)/version"
+cd cf-smoke-tests-release/src/smoke_tests
+go mod edit -json | jq --raw-output .Go > "${version_output}/version"

--- a/ci/tasks/get-submodule-go-version/task.yml
+++ b/ci/tasks/get-submodule-go-version/task.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: bosh/golang-release
+
+inputs:
+- name: cf-smoke-tests-release
+
+outputs:
+- name: version
+
+run:
+  path: cf-smoke-tests-release/ci/tasks/get-submodule-go-version/task.sh


### PR DESCRIPTION
This PR changes the repo's CI pipeline to make it automatically bump the versions of `go`, and go modules, in [cf-smoke-tests](https://github.com/cloudfoundry/cf-smoke-tests), plus the version of the golang package in cf-smoke-tests-release and references to it in related files. I also update a few outdated sections of the docs, and make some little tweaks to the pipeline (e.g. yaml anchors to release the pool if a job doesn't finish successfully, groups to tidy how it looks in the UI).

As we want to automatically update the golang package to new versions (#10), it seems sensible to track the `go` version in [go.mod](https://github.com/cloudfoundry/cf-smoke-tests/blob/main/go.mod) in cf-smoke-tests. That version is currently bumped by hand, while other dependencies in that file are managed by [dependabot](https://github.com/cloudfoundry/cf-smoke-tests/blob/11edaa89e67680fbbc2bfcc10c99165e36f23fbc/.github/dependabot.yml).

It's better to bump go and go dependencies with the same tool, and this PR would do that with Concourse. An alternative would be to just update both with dependabot, and I think I'm easy either way on that one.

I've added some new tasks to this repo, but I see your existing tasks are in [cloudfoundry/runtime-ci](https://github.com/cloudfoundry/runtime-ci), so I can PR them there instead if you prefer.

This has been running in a pipeline [here](https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-smoke-tests) (it's public), happily bumping dependencies on forks of the two repos and cutting new releases.

![Screenshot 2022-07-26 at 20 44 48](https://user-images.githubusercontent.com/20523607/181098635-33416301-9326-43a0-be29-9a06b1cef408.png)
![Screenshot 2022-07-26 at 20 44 53](https://user-images.githubusercontent.com/20523607/181098645-5b65b006-9a4f-4b83-9635-385df20fb267.png)

