### PR TITLE
CI: remove cf-test-helpers trigger from update-smoke-tests job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -62,13 +62,6 @@ resources:
     branch: main
     private_key: ((cf_smoke_tests_readwrite_deploy_key.private_key))
 
-- name: cf-test-helpers
-  type: git
-  icon: github
-  source:
-    uri: https://github.com/cloudfoundry/cf-test-helpers
-    branch: main
-
 - name: relint-envs
   type: git
   icon: github
@@ -113,8 +106,6 @@ jobs:
   plan:
   - in_parallel:
     - get: golang-release
-      trigger: true
-    - get: cf-test-helpers
       trigger: true
     - get: runtime-ci
     - get: cf-smoke-tests


### PR DESCRIPTION
We should be cutting releases of cf-test-helpers now, and letting dependabot bump the version in cf-smoke-tests.