### PR TITLE
CI: update cats env system domain

### DIFF
--- a/ci/configure
+++ b/ci/configure
@@ -2,7 +2,7 @@
 
 main() {
   set -ex
-  fly -t relint-ci sp -p cf-smoke-tests -c "${PROJECT_DIR}/ci/pipeline.yml"
+  fly -t ard sp -p cf-smoke-tests -c "${PROJECT_DIR}/ci/pipeline.yml"
 }
 
 main "$@"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -202,7 +202,7 @@ jobs:
       bbl-state: relint-envs
     params:
       BBL_STATE_DIR: environments/test/cats/bbl-state
-      SYSTEM_DOMAIN: cats.cf-app.com
+      SYSTEM_DOMAIN: cf.cats.env.wg-ard.ci.cloudfoundry.org
       CREDHUB_ENV_NAME: bosh-cats
 
 - name: run-smokes-errand


### PR DESCRIPTION
The pipeline needs the new system domain after the env migration.

Should be merged at the same time as: https://github.com/cloudfoundry/cf-deployment/pull/1010.