### PR TITLE
CI: increase check duration for certain resources

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -104,11 +104,13 @@ resources:
 
 - name: golang-release
   type: git
+  check_every: 12h
   source:
     uri: https://github.com/bosh-packages/golang-release.git
 
 - name: cf-cli-release
   type: github-release
+  check_every: 12h
   source:
     owner: cloudfoundry
     repository: cli


### PR DESCRIPTION
`golang-release` and `cf-cli-release` resources are triggers for jobs and have been running up against GH API constraints.

The default check duration is 1 minute, which seems unnecessary for these resources. Both repos only add new commits / cut releases every few weeks or so. Increasing the [`check_every` field](https://concourse-ci.org/resources.html#schema.resource.check_every) to 12 hours should reduce load on concourse & the GH API while still providing good coverage for triggering jobs.