### PR TITLE
CI: fix update-release job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -172,7 +172,7 @@ jobs:
         blobstore:
           options:
             credentials_source: static
-            json_key: ((ci_dev_gcp_service_account_json))
+            json_key: '((ci_dev_gcp_service_account_json))'
   - task: bump-cf-cli-windows-blob
     file: runtime-ci/tasks/bump-cf-cli-windows-blob/task.yml
     input_mapping:
@@ -185,7 +185,7 @@ jobs:
         blobstore:
           options:
             credentials_source: static
-            json_key: ((ci_dev_gcp_service_account_json))
+            json_key: '((ci_dev_gcp_service_account_json))'
   - put: cf-smoke-tests-release
     params:
       repository: cf-smoke-tests-release


### PR DESCRIPTION
[bump-release-go-package task](https://github.com/cloudfoundry/bosh-package-golang-release/blob/main/ci/tasks/shared/bump-golang-package.yml) appears to parse the provided yaml string in such a way that the json key is output as straight JSON. This results in errors like:

```
Marshaling config:
      json: unsupported type: map[interface {}]interface {}
```

Wrapping the value in single quotes identifies it as a string and prevents JSON ummarshalling errors.